### PR TITLE
use default config file name marbles1.json

### DIFF
--- a/utils/helper.js
+++ b/utils/helper.js
@@ -5,6 +5,12 @@ var crypto = require('crypto');
 
 module.exports = function (config_filename, logger) {
 	var helper = {};
+
+    // default config file name
+    if (!config_filename) {
+        config_filename = "marbles1.json";
+    }
+    
 	var config_path = path.join(__dirname, '../config/' + config_filename);
 	helper.config = require(config_path);
 	var creds_path = path.join(__dirname, '../config/' + helper.config.cred_filename);


### PR DESCRIPTION
I just hardcoded the default config file name as `marblesv1.json` in `utils/helper.js`.  Let me know if you want me to make this something more sophisticated.  This PR resolves issues with using the application in cloud foundry since it uses `npm start` instead of `gulp marblesv1`, which leaves the config file name is undefined.