### PR TITLE
Get the v3.0 branch of Marbles app

### DIFF
--- a/docs/tutorial_start_here.md
+++ b/docs/tutorial_start_here.md
@@ -91,7 +91,7 @@ Let’s do this with Git by cloning this repository.
 You will need to do this step even if you plan on hosting marbles in Bluemix.
 
 - Open a command prompt/terminal and browse to your desired working directory
-- Run the following commands:
+- Run the following command:
 
 ```
 git clone -b v3.0 http://gopkg.in/ibm-blockchain/marbles.v3

--- a/docs/tutorial_start_here.md
+++ b/docs/tutorial_start_here.md
@@ -91,10 +91,11 @@ Let’s do this with Git by cloning this repository.
 You will need to do this step even if you plan on hosting marbles in Bluemix.
 
 - Open a command prompt/terminal and browse to your desired working directory
-- Run the following command:
+- Run the following commands:
 
 ```
 git clone http://gopkg.in/ibm-blockchain/marbles.v3
+git checkout -b v3.0
 ```
 
 - This will clone the v3.0 branch to your local system. 

--- a/docs/tutorial_start_here.md
+++ b/docs/tutorial_start_here.md
@@ -94,8 +94,7 @@ You will need to do this step even if you plan on hosting marbles in Bluemix.
 - Run the following commands:
 
 ```
-git clone http://gopkg.in/ibm-blockchain/marbles.v3
-git checkout -b v3.0
+git clone -b v3.0 http://gopkg.in/ibm-blockchain/marbles.v3
 ```
 
 - This will clone the v3.0 branch to your local system. 


### PR DESCRIPTION
The `git` command to clone the Marbles repo was only pulling down the master branch.  This change will get the v3.0 branch.