### PR TITLE
add stream-buffers as dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,9 @@
     "express-session": "1.14.*",
     "fabric-ca-client": "1.0.0-alpha.0",
     "fabric-client": "1.0.0-alpha",
-	"pug": "2.0.0-beta11",
+    "pug": "2.0.0-beta11",
     "serve-static": "1.11.*",
+    "stream-buffers": "^3.0.1",
     "winston": "2.2.*",
     "ws": "1.1.*"
   },


### PR DESCRIPTION
@dshuffma-ibm I was seeing the following when trying to run marbles:

```
info: Loaded config file /Users/edward/Documents/Workspaces/fabric-kubernetes/marbles/marbles/config/marbles1.json
info: Loaded creds file /Users/edward/Documents/Workspaces/fabric-kubernetes/marbles/marbles/config/blockchain_creds1.json
info: Returning a new winston logger with default configurations
module.js:471
    throw err;
    ^

Error: Cannot find module 'stream-buffers'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/edward/Documents/Workspaces/fabric-kubernetes/marbles/marbles/node_modules/fabric-client/lib/packager/Golang.js:23:12)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
```

So I ran `npm install --save stream-buffers` to add this dependency to the `package.json`.