### PR TITLE
blockchain-ca port updated for kubernetes cluster

### DIFF
--- a/config/blockchain_cs.json
+++ b/config/blockchain_cs.json
@@ -56,7 +56,7 @@
 	},
 	"certificateAuthorities": {
 		"blockchain-ca": {
-			"url": "http://blockchain-ca:7054",
+			"url": "http://blockchain-ca:30000",
 			"httpOptions": {
 				"verify": true
 			},


### PR DESCRIPTION
bluemix kubernetes blockchain service's "blockchain-ca" port updated for cluster from 7054 to 30000