### PR TITLE
Script typo

### DIFF
--- a/docs/use_local_hyperledger.md
+++ b/docs/use_local_hyperledger.md
@@ -86,7 +86,7 @@ Finally lets test the network before we run marbles.
 Run query via `fabcar` with the commands:
 
 ```bash
-    node enrollAdmins.js
+    node enrollAdmin.js
     node registerUser.js
     node query.js
 ```


### PR DESCRIPTION
The script to enroll an admin is singular not plural.