### PR TITLE
fix the failure of private key missing from keystore

### DIFF
--- a/config/connection_profile_local.json
+++ b/config/connection_profile_local.json
@@ -7,7 +7,7 @@
 	"client": {
 		"organization": "Org1MSP",
 		"credentialStore": {
-			"path": "/$HOME/fabric-samples/fabcar/hfc-key-store"
+			"path": "/$HOME/fabric-samples/fabcar"
 		}
 	},
 	"channels": {


### PR DESCRIPTION
fix the failure: Private key missing from key store. Can not establish the signing identity for user admin.
Due to finding private key form hfc-key-store acquiescently, so add hfc-key-store will couldn't find the key.